### PR TITLE
fixed issue where the plugins project not picking up namespace

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -170,8 +170,10 @@ module.exports = yeoman.Base.extend({
   _writePluginProject : function() {
     var pluginProjectName = this.props.visualStudioSolutionProjectPrefix + '.Xrm.Plugins'; 
     this.fs.copyTpl(
-      this.templatePath('Project.Xrm.Plugins/Project.Xrm.Plugins.csproj'),
-      this.destinationPath(pluginProjectName + '/'+ pluginProjectName + '.csproj')
+        this.templatePath('Project.Xrm.Plugins/Project.Xrm.Plugins.csproj'),
+        this.destinationPath(pluginProjectName + '/'+ pluginProjectName + '.csproj'), {
+          pluginProjectName: pluginProjectName
+        }
     );
 
     this.fs.copyTpl(

--- a/generators/app/templates/Project.Xrm.Plugins/Project.Xrm.Plugins.csproj
+++ b/generators/app/templates/Project.Xrm.Plugins/Project.Xrm.Plugins.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{F82EC072-B2BD-4A6C-8C89-F942BE9F5783}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Project.Xrm.Plugins</RootNamespace>
-    <AssemblyName>Project.Xrm.Plugins</AssemblyName>
+    <RootNamespace><%= pluginProjectName %></RootNamespace>
+    <AssemblyName><%= pluginProjectName %></AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>


### PR DESCRIPTION
Fixed issue where the plugin project was not picking up the namespace provided.

It was setting the `assembly name` and 'default namespace' to the default template namespace